### PR TITLE
Add thread_pool and fitness_updater modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 crossbeam = "0.8.2"
 topo_sort = "0.4"
+rstest = "0.17.0"
 
 [build]
 profiler = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ rand = "0.8.5"
 rand_distr = "0.4.3"
 crossbeam = "0.8.2"
 topo_sort = "0.4"
+
+[dev-dependencies]
 rstest = "0.17.0"
 
 [build]

--- a/src/community.rs
+++ b/src/community.rs
@@ -2,6 +2,7 @@ mod community_params;
 pub mod genome;
 mod organism;
 mod species;
+mod fitness_calculator;
 
 use crate::community::genome::Genome;
 use crate::community::species::Species;

--- a/src/community/fitness_updater.rs
+++ b/src/community/fitness_updater.rs
@@ -1,0 +1,139 @@
+use super::Organism;
+use crate::concurrency::Execute;
+use std::sync::mpsc::{channel, Receiver, Sender};
+
+// Utility struct for updating a vector of organisms' fitnesses according
+// to a fitness function. Concurrency and parallelism can be achieved by using a
+// specified executor `T` to run the fitness function on each organism.
+pub struct FitnessUpdater<T>
+where
+    T: Execute,
+{
+    executor: T,
+    sender: Sender<(usize, f64)>,
+    receiver: Receiver<(usize, f64)>,
+}
+
+impl<T> FitnessUpdater<T>
+where
+    T: Execute,
+{
+    // Creates a new FitnessUpdater with the specified executor.
+    pub fn new(executor: T) -> Self {
+        let (sender, receiver) = channel();
+        Self {
+            executor,
+            sender,
+            receiver,
+        }
+    }
+
+    // Updates the fitness of each organism in the vector according to the
+    // specified fitness function. This may run concurrently depending on the
+    // executor used, but calling this function will block until all organisms
+    // have been updated.
+    pub fn update_fitness(&self, mut orgs: &Vec<Organism>, fitness_func: fn(&Organism) -> f64) {
+        orgs.iter().enumerate().for_each(|(i, org)| {
+            let sender = self.sender.clone();
+            self.executor.execute(move || {
+                let fitness = fitness_func(&org);
+                sender.send((i, fitness)).unwrap();
+            });
+        });
+        self.receiver
+            .iter()
+            .take(orgs.len())
+            .for_each(|(i, fitness)| {
+                orgs[i].raw_fitness = Some(fitness);
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::{fixture, rstest};
+
+    // Need this to construct organisms
+    use crate::community::genome;
+
+    #[fixture]
+    fn orgs_ascending_fitness(#[default(0)] num: usize) -> Vec<Organism> {
+        (0..num)
+            .into_iter()
+            .map(|i| {
+                let genome = genome::Genome::new_dense(1, 1);
+                let mut org = Organism::new(genome);
+                org.raw_fitness = Some(i as f64);
+                org
+            })
+            .collect()
+    }
+
+    #[fixture]
+    fn ffunc_negate() -> fn(&Organism) -> f64 {
+        |org: &Organism| -org.get_fitness().unwrap()
+    }
+
+    #[fixture]
+    fn ffunc_ones() -> fn(&Organism) -> f64 {
+        |_: &Organism| 1.0
+    }
+
+    #[fixture]
+    fn mock_executor() -> impl Execute {
+        struct MockExecutor {
+            sender: Sender<()>,
+        }
+        impl Execute for MockExecutor {
+            fn execute<F>(&self, f: F)
+            where
+                F: FnOnce() + Send + 'static,
+            {
+                f();
+                self.sender.send(()).unwrap();
+            }
+        }
+        let (sender, _) = channel();
+        MockExecutor { sender }
+    }
+
+    #[rstest]
+    fn test_empty(
+        mock_executor: impl Execute,
+        #[with(0)] #[from(orgs_ascending_fitness)] orgs: Vec<Organism>,
+        ffunc_ones: fn(&Organism) -> f64,
+    ) {
+        let updater = FitnessUpdater::new(crate::concurrency::thread_pool::ThreadPool::new(4));
+        let orgs = vec![];
+        updater.update_fitness(&orgs, ffunc_ones);
+        assert_eq!(orgs.len(), 0);
+    }
+
+    #[rstest]
+    fn test_single(
+        mock_executor: impl Execute,
+        #[with(1)] #[from(orgs_ascending_fitness)] orgs: Vec<Organism>,
+        ffunc_ones: fn(&Organism) -> f64,
+    ) {
+        let updater = FitnessUpdater::new(mock_executor);
+        updater.update_fitness(&orgs, ffunc_ones);
+        assert_eq!(orgs.len(), 1);
+        assert_eq!(orgs[0].get_fitness().unwrap(), 1.0);
+    }
+
+    #[rstest]
+    fn test_multiple_ordering_matters(
+        mock_executor: impl Execute,
+        #[with(3)] #[from(orgs_ascending_fitness)] orgs: Vec<Organism>,
+        ffunc_negate: fn(&Organism) -> f64,
+    ) {
+        let updater = FitnessUpdater::new(mock_executor);
+        updater.update_fitness(&orgs, ffunc_negate);
+
+        assert_eq!(orgs.len(), 3);
+        assert_eq!(orgs[0].get_fitness().unwrap(), -0.0);
+        assert_eq!(orgs[1].get_fitness().unwrap(), -1.0);
+        assert_eq!(orgs[2].get_fitness().unwrap(), -2.0);
+    }
+}

--- a/src/community/organism.rs
+++ b/src/community/organism.rs
@@ -3,14 +3,22 @@ use crate::community::genome::Genome;
 #[derive(Debug)]
 pub struct Organism {
     pub genome: Genome,
-    pub raw_fitness: f64,
+    pub raw_fitness: Option<f64>,
 }
 
 impl Organism {
     pub fn new(genome: Genome) -> Organism {
         Organism {
             genome,
-            raw_fitness: -1.0,
+            raw_fitness: None,
         }
+    }
+
+    pub fn get_fitness(&self) -> Option<f64> {
+        self.raw_fitness
+    }
+
+    pub fn set_fitness(&mut self, fitness: f64) {
+        self.raw_fitness = Some(fitness);
     }
 }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,0 +1,5 @@
+pub trait Execute {
+    fn execute<F>(&self, f: F) where F: FnOnce() + Send + 'static;
+}
+
+pub mod thread_pool;

--- a/src/concurrency/thread_pool.rs
+++ b/src/concurrency/thread_pool.rs
@@ -1,0 +1,132 @@
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use crate::concurrency::Execute;
+
+type Task = Box<dyn FnOnce() + Send + 'static>;
+
+struct Worker {
+    _id: usize,
+    _thread: thread::JoinHandle<()>,
+}
+
+impl Worker {
+    fn new(id: usize, receiver: Arc<Mutex<Receiver<Task>>>) -> Self {
+        let thread_name = format!("worker-{}", id);
+        let _thread = thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || loop {
+
+                let task = receiver.lock().unwrap().recv().unwrap();
+                task();
+            })
+            .unwrap();
+        Self { _id: id, _thread }
+    }
+}
+
+pub struct ThreadPool {
+    _workers: Vec<Worker>,
+    task_sender: Sender<Task>,
+}
+
+impl ThreadPool {
+    pub fn new(size: usize) -> Self {
+        assert!(size > 0);
+        let (task_sender, task_receiver) = channel();
+        let task_receiver = Arc::new(Mutex::new(task_receiver));
+        let mut _workers = Vec::with_capacity(size);
+        for id in 0..size {
+            _workers.push(Worker::new(id, Arc::clone(&task_receiver)));
+        }
+        Self {
+            _workers,
+            task_sender,
+        }
+    }
+}
+
+impl Execute for ThreadPool {
+    fn execute<F>(&self, f: F) 
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        self.task_sender.send(Box::new(f)).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Execute;
+    use super::ThreadPool;
+    use std::sync::mpsc::channel;
+    use std::thread::sleep;
+    use std::time;
+
+    #[test]
+    fn test_simple() {
+        let tp = ThreadPool::new(4);
+        let (tx, rx) = channel();
+
+        for i in 0..10 {
+            let tx = tx.clone();
+            tp.execute(move || {
+                tx.send(i).expect("send failed");
+            });
+        }
+
+        // sum([0, 1, 2, ..., 9] == 45)
+        assert_eq!(rx.iter().take(10).sum::<usize>(), 45);
+
+    }
+
+    #[test]
+    fn test_concurrency() {
+        let task_duration = time::Duration::from_millis(500);
+        let (tx, rx) = channel();
+
+        // 2 threads for 2 tasks
+        let tp = ThreadPool::new(2);
+
+        let time_start = time::Instant::now();
+
+        for i in 0..2 {
+            let tx = tx.clone();
+            tp.execute(move || {
+                sleep(task_duration);
+                tx.send(i).expect("send failed");
+            });
+        }
+
+        // consume both results
+        rx.iter().take(2).for_each(|_| {});
+
+        // The only way for this to be true is if the tasks were executed concurrently
+        assert!(time_start.elapsed() < 2 * task_duration);
+    }
+
+    #[test]
+    fn test_limited_concurrency() {
+        let task_duration = time::Duration::from_millis(500);
+        let (tx, rx) = channel();
+
+        // 1 thread for 2 tasks
+        let tp = ThreadPool::new(1);
+
+        let time_start = time::Instant::now();
+
+        for i in 0..2 {
+            let tx = tx.clone();
+            tp.execute(move || {
+                sleep(task_duration);
+                tx.send(i).expect("send failed");
+            });
+        }
+
+        // consume both results
+        rx.iter().take(2).for_each(|_| {});
+
+        // This should only be true if the tasks were *not* executed concurrently
+        assert!(time_start.elapsed() >= 2 * task_duration);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod neural_network;
 mod community;
+mod concurrency;
 
 pub fn add(left: usize, right: usize) -> usize {
     left + right


### PR DESCRIPTION
I've tested `thread_pool` but haven't tested `fitness_updater` because it has library dependencies, so this is a draft PR (i wish non-org accounts had actual draft PRs) until the library is compiling and the tests can run.

## `thread_pool`
Generic thread pool class in a new `concurrency` module. My idea was that users should be able to easily change the concurrency strategy, so it implements an `Execute` trait which is all `fitness_updater` requires. We/users could also implement an async executor (consider a fitness func that just makes an API request), or a GPU executor, or whatever else. This and other executors expect a void function as an argument, so getting return values back requires using channels or some other form of messaging. `fitness_updater` uses a channel and wraps the fitness function in a closure that sends the return value back.

## `fitness_updater`
This is basically just an abstraction for updating the fitness of a vector of organisms using some executor (like a `thread_pool`). It presents as a blocking function. If you'd like to keep things more functional we could change it to return a new vector or something instead of requiring a mutable reference to the vector of organisms.